### PR TITLE
project list status correction

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  info = "info",
   warning = "warning",
-  critical = "critical",
+  error = "error",
 }
 
 export type Project = {

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,5 +1,13 @@
 import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
+import { ProjectStatus } from "@api/projects.types";
+
+// Mapping for status display text
+const statusText: { [key in ProjectStatus]: string } = {
+  [ProjectStatus.info]: "Stable",
+  [ProjectStatus.warning]: "Warning",
+  [ProjectStatus.error]: "Critical",
+};
 
 describe("Project List", () => {
   beforeEach(() => {
@@ -28,11 +36,25 @@ describe("Project List", () => {
         .find("li")
         .each(($el, index) => {
           // check that project data is rendered
-          cy.wrap($el).contains(mockProjects[index].name);
+          // cy.wrap($el).contains(mockProjects[index].name);
+          // cy.wrap($el).contains(languageNames[index]);
+          // cy.wrap($el).contains(mockProjects[index].numIssues);
+          // cy.wrap($el).contains(mockProjects[index].numEvents24h);
+          // cy.wrap($el).contains(capitalize(mockProjects[index].status));
+
+          const project = mockProjects[index];
+
+          // check that project data is rendered
+          cy.wrap($el).contains(project.name);
           cy.wrap($el).contains(languageNames[index]);
-          cy.wrap($el).contains(mockProjects[index].numIssues);
-          cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el).contains(project.numIssues);
+          cy.wrap($el).contains(project.numEvents24h);
+
+          // Check for the correct status text
+          const expectedStatusText =
+            statusText[project.status as ProjectStatus];
+          cy.wrap($el).contains(capitalize(expectedStatusText));
+
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -33,7 +33,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: ProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -17,9 +17,15 @@ const languageNames = {
 };
 
 const statusColors = {
-  [ProjectStatus.stable]: BadgeColor.success,
+  [ProjectStatus.info]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  [ProjectStatus.error]: BadgeColor.error,
+};
+
+const statusText = {
+  [ProjectStatus.info]: "Stable",
+  [ProjectStatus.warning]: "Warning",
+  [ProjectStatus.error]: "Critical",
 };
 
 export function ProjectCard({ project }: ProjectCardProps) {
@@ -50,7 +56,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <div className={styles.issuesNumber}>{numEvents24h}</div>
           </div>
           <div className={styles.status}>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>
+              {capitalize(statusText[status])}
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Project card now shows 'Critical' when status is error, and shows 'Stable' when status is info. Text colors are also changed accordingly.